### PR TITLE
Add configuration flag to control snapshot creation

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -15,3 +15,6 @@ csvSeparator=,
 
 # Indicates whether the CSV file includes a header row (default true)
 csvHasHeader=true
+
+# Controls whether a blob snapshot is created prior to deletion to enable soft-delete recovery
+snapshotEnable=true

--- a/src/main/java/com/example/batchdelete/config/AppConfig.java
+++ b/src/main/java/com/example/batchdelete/config/AppConfig.java
@@ -21,9 +21,10 @@ public final class AppConfig {
     private final int threadPoolSize;
     private final String csvSeparator;
     private final boolean csvHasHeader;
+    private final boolean snapshotEnabled;
 
     private AppConfig(String inputFilePath, String storageEndpoint, int batchSize, int threadPoolSize,
-            String csvSeparator, boolean csvHasHeader) {
+            String csvSeparator, boolean csvHasHeader, boolean snapshotEnabled) {
         if (batchSize <= 0 || batchSize > MAX_BATCH_SIZE) {
             throw new IllegalArgumentException(
                     "batchSize must be between 1 and " + MAX_BATCH_SIZE + ", but was " + batchSize);
@@ -37,6 +38,7 @@ public final class AppConfig {
         this.threadPoolSize = threadPoolSize;
         this.csvSeparator = csvSeparator == null || csvSeparator.isEmpty() ? DEFAULT_SEPARATOR : csvSeparator;
         this.csvHasHeader = csvHasHeader;
+        this.snapshotEnabled = snapshotEnabled;
     }
 
     public String getInputFilePath() {
@@ -63,6 +65,10 @@ public final class AppConfig {
         return csvHasHeader;
     }
 
+    public boolean isSnapshotEnabled() {
+        return snapshotEnabled;
+    }
+
     public static AppConfig load(Path path) throws IOException {
         Properties properties = new Properties();
         try (InputStream inputStream = Files.newInputStream(path)) {
@@ -75,8 +81,10 @@ public final class AppConfig {
         int threadPoolSize = parseIntProperty(properties, "threadPoolSize", Runtime.getRuntime().availableProcessors());
         String csvSeparator = properties.getProperty("csvSeparator", DEFAULT_SEPARATOR);
         boolean csvHasHeader = parseBooleanProperty(properties, "csvHasHeader", true);
+        boolean snapshotEnabled = parseBooleanProperty(properties, "snapshotEnable", false);
 
-        return new AppConfig(inputFilePath, storageEndpoint, batchSize, threadPoolSize, csvSeparator, csvHasHeader);
+        return new AppConfig(inputFilePath, storageEndpoint, batchSize, threadPoolSize, csvSeparator, csvHasHeader,
+                snapshotEnabled);
     }
 
     private static String requireProperty(Properties properties, String propertyName) {

--- a/src/main/java/com/example/batchdelete/service/BlobBatchDeletionService.java
+++ b/src/main/java/com/example/batchdelete/service/BlobBatchDeletionService.java
@@ -62,7 +62,8 @@ public class BlobBatchDeletionService {
         try {
             for (int i = 0; i < config.getThreadPoolSize(); i++) {
                 CompletableFuture<BatchDeletionResult> future = CompletableFuture
-                        .supplyAsync(() -> processQueue(blobBatchClient, requestQueue, config.getBatchSize()),
+                        .supplyAsync(() -> processQueue(blobBatchClient, blobServiceClient, requestQueue,
+                                config.getBatchSize()),
                                 executorService)
                         .exceptionally(throwable -> {
                             Throwable cause = throwable instanceof CompletionException ? throwable.getCause()
@@ -101,8 +102,8 @@ public class BlobBatchDeletionService {
         }
     }
 
-    private BatchDeletionResult processQueue(BlobBatchClient blobBatchClient, Queue<BlobDeleteRequest> requestQueue,
-                                             int batchSize) {
+    private BatchDeletionResult processQueue(BlobBatchClient blobBatchClient, BlobServiceClient blobServiceClient,
+                                             Queue<BlobDeleteRequest> requestQueue, int batchSize) {
         BatchDeletionResult totalResult = new BatchDeletionResult(0, 0);
 
         while (true) {
@@ -119,7 +120,8 @@ public class BlobBatchDeletionService {
                 break;
             }
 
-            BlobBatchDeletionTask task = new BlobBatchDeletionTask(blobBatchClient, batch);
+            BlobBatchDeletionTask task = new BlobBatchDeletionTask(blobBatchClient, blobServiceClient, batch,
+                    config.isSnapshotEnabled());
             BatchDeletionResult result = task.call();
             totalResult = totalResult.add(result);
         }


### PR DESCRIPTION
## Summary
- add a snapshotEnable configuration property with a getter so the batch deletion service can determine whether soft-delete snapshots should be created
- pass the configuration flag into BlobBatchDeletionTask and skip snapshot creation when disabled while preserving existing deletion logging
- document the new property in `application.properties`

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d51d2122e48320a8593e3ca490119c