### PR TITLE
Add CLI overrides and inline CSV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The CSV file must contain at least two columns per line:
 
 Additional columns are ignored. If the file includes a header row, make sure `csvHasHeader` is set to `true` (default).
 
+Alternatively, you can embed the CSV payload directly in the configuration by setting `inputCsvContent` instead of
+`inputFilePath`. Only one of these properties can be defined at a time.
+
 Example:
 
 ```
@@ -85,9 +88,19 @@ The output artifact will be generated at `target/batch-blob-delete-1.0.0-shaded.
 After building, run the application with:
 
 ```bash
-java -jar target/batch-blob-delete-1.0.0-shaded.jar [path-to-config]
+java -jar target/batch-blob-delete-1.0.0-shaded.jar [options]
 ```
 
-If no argument is provided, `config/application.properties` is used.
+Common options:
+
+| Option | Description |
+|--------|-------------|
+| `-c, --config <path>` | Path to the configuration file (default: `config/application.properties`). |
+| `-f, --input-file <path>` | Override the CSV file path defined in the configuration file. |
+| `-d, --input-data <csv>` | Provide the CSV payload inline (mutually exclusive with `--input-file`). |
+| `-h, --help` | Prints CLI usage information. |
+
+When `--input-data` is provided, the CSV content is read directly from the argument, which is convenient when invoking the tool
+from other Java processes.
 
 The application logs progress, successes, and failures to the console using Log4j 2. Logs can be redirected or reconfigured by editing `src/main/resources/log4j2.xml`.

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,5 +1,9 @@
 # Path to the input CSV file containing container and blob names to delete.
+# Alternatively, comment this out and set inputCsvContent with the CSV payload.
 inputFilePath=./data/input.csv
+
+# Example inline CSV configuration (uncomment to use instead of inputFilePath)
+# inputCsvContent="container,blob\narchive,backup/file.zip"
 
 # Azure Blob Storage service endpoint, e.g. https://<account-name>.blob.core.windows.net
 storageEndpoint=https://your-storage-account.blob.core.windows.net

--- a/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
+++ b/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 public final class BatchBlobDeleteApplication {
 
@@ -15,10 +16,29 @@ public final class BatchBlobDeleteApplication {
     }
 
     public static void main(String[] args) {
+        CliArguments cliArguments;
         try {
-            Path configPath = resolveConfigPath(args);
-            AppConfig config = AppConfig.load(configPath);
-            LOGGER.info("Starting Batch Blob Delete application with input file {}", config.getInputFilePath());
+            cliArguments = CliArguments.parse(args);
+        } catch (IllegalArgumentException ex) {
+            System.err.println("Error: " + ex.getMessage());
+            CliArguments.printUsage();
+            System.exit(1);
+            return;
+        }
+
+        try {
+            if (cliArguments.help()) {
+                CliArguments.printUsage();
+                return;
+            }
+
+            Path configPath = cliArguments.configPath().orElseGet(() -> Path.of("config", "application.properties"));
+            AppConfig config = AppConfig.load(configPath, cliArguments.inputFilePath().orElse(null),
+                    cliArguments.inputCsvData().orElse(null));
+
+            LOGGER.info("Starting Batch Blob Delete application with {}",
+                    config.getInputFilePath().<CharSequence>map(path -> "input file " + path)
+                            .orElse("inline CSV content"));
 
             BlobBatchDeletionService service = new BlobBatchDeletionService(config);
             service.execute();
@@ -28,10 +48,70 @@ public final class BatchBlobDeleteApplication {
         }
     }
 
-    private static Path resolveConfigPath(String[] args) {
-        if (args != null && args.length > 0) {
-            return Path.of(args[0]);
+    private record CliArguments(Optional<Path> configPath, Optional<String> inputFilePath, Optional<String> inputCsvData,
+            boolean help) {
+
+        private static CliArguments parse(String[] args) {
+            if (args == null || args.length == 0) {
+                return new CliArguments(Optional.empty(), Optional.empty(), Optional.empty(), false);
+            }
+
+            Path configPath = null;
+            String inputFile = null;
+            String inputCsv = null;
+            boolean help = false;
+
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                switch (arg) {
+                    case "--help":
+                    case "-h":
+                        help = true;
+                        break;
+                    case "--config":
+                    case "-c":
+                        configPath = Path.of(requireValue(arg, args, ++i));
+                        break;
+                    case "--input-file":
+                    case "-f":
+                        inputFile = requireValue(arg, args, ++i);
+                        break;
+                    case "--input-data":
+                    case "-d":
+                        inputCsv = requireValue(arg, args, ++i);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown argument: " + arg);
+                }
+            }
+
+            if (!isBlank(inputFile) && !isBlank(inputCsv)) {
+                throw new IllegalArgumentException("--input-file and --input-data cannot be used together");
+            }
+
+            return new CliArguments(Optional.ofNullable(configPath), Optional.ofNullable(inputFile),
+                    Optional.ofNullable(inputCsv), help);
         }
-        return Path.of("config", "application.properties");
+
+        private static String requireValue(String currentArg, String[] args, int valueIndex) {
+            if (valueIndex >= args.length) {
+                throw new IllegalArgumentException("Missing value for argument " + currentArg);
+            }
+            return args[valueIndex];
+        }
+
+        static void printUsage() {
+            String usage = "Usage: java -jar batch-blob-delete.jar [options]\n" +
+                    "Options:\n" +
+                    "  -c, --config <path>       Path to configuration file (default: config/application.properties)\n" +
+                    "  -f, --input-file <path>   Override input CSV file path\n" +
+                    "  -d, --input-data <csv>    Provide inline CSV data (mutually exclusive with --input-file)\n" +
+                    "  -h, --help                Show this help message";
+            System.out.println(usage);
+        }
+
+        private static boolean isBlank(String value) {
+            return value == null || value.isBlank();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a lightweight CLI parser so configuration file, CSV file override, inline CSV payload, and help can be provided from the command line
- extend the configuration and CSV reader to handle inline CSV content and expose helpers in the deletion service for programmatic execution
- refresh the README and sample configuration to document CLI usage and inline CSV options

## Testing
- mvn -q -DskipTests package *(fails: com.azure.storage.blob.models.BlobSnapshotInfo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd7011bf08320b3f68ecd38e8c083