### PR TITLE
Add CLI overrides and propagate batch failures

### DIFF
--- a/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
+++ b/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
@@ -1,6 +1,7 @@
 package com.example.batchdelete;
 
 import com.example.batchdelete.config.AppConfig;
+import com.example.batchdelete.service.BatchDeletionResult;
 import com.example.batchdelete.service.BlobBatchDeletionService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,14 +35,19 @@ public final class BatchBlobDeleteApplication {
 
             Path configPath = cliArguments.configPath().orElseGet(() -> Path.of("config", "application.properties"));
             AppConfig config = AppConfig.load(configPath, cliArguments.inputFilePath().orElse(null),
-                    cliArguments.inputCsvData().orElse(null));
+                    cliArguments.inputCsvData().orElse(null), cliArguments.batchSize().orElse(null),
+                    cliArguments.threadCount().orElse(null));
 
             LOGGER.info("Starting Batch Blob Delete application with {}",
                     config.getInputFilePath().<CharSequence>map(path -> "input file " + path)
                             .orElse("inline CSV content"));
 
             BlobBatchDeletionService service = new BlobBatchDeletionService(config);
-            service.execute();
+            BatchDeletionResult result = service.execute();
+            if (result.failureCount() > 0) {
+                LOGGER.error("Batch completed with {} failures", result.failureCount());
+                System.exit(1);
+            }
         } catch (Exception ex) {
             LOGGER.fatal("Application failed", ex);
             System.exit(1);
@@ -49,16 +55,19 @@ public final class BatchBlobDeleteApplication {
     }
 
     private record CliArguments(Optional<Path> configPath, Optional<String> inputFilePath, Optional<String> inputCsvData,
-            boolean help) {
+            Optional<Integer> batchSize, Optional<Integer> threadCount, boolean help) {
 
         private static CliArguments parse(String[] args) {
             if (args == null || args.length == 0) {
-                return new CliArguments(Optional.empty(), Optional.empty(), Optional.empty(), false);
+                return new CliArguments(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), false);
             }
 
             Path configPath = null;
             String inputFile = null;
             String inputCsv = null;
+            Integer batchSize = null;
+            Integer threadCount = null;
             boolean help = false;
 
             for (int i = 0; i < args.length; i++) {
@@ -80,6 +89,14 @@ public final class BatchBlobDeleteApplication {
                     case "-d":
                         inputCsv = requireValue(arg, args, ++i);
                         break;
+                    case "--batch-size":
+                    case "-b":
+                        batchSize = parsePositiveInt(requireValue(arg, args, ++i), "batch size", 256);
+                        break;
+                    case "--threads":
+                    case "-t":
+                        threadCount = parsePositiveInt(requireValue(arg, args, ++i), "thread count", null);
+                        break;
                     default:
                         throw new IllegalArgumentException("Unknown argument: " + arg);
                 }
@@ -90,7 +107,8 @@ public final class BatchBlobDeleteApplication {
             }
 
             return new CliArguments(Optional.ofNullable(configPath), Optional.ofNullable(inputFile),
-                    Optional.ofNullable(inputCsv), help);
+                    Optional.ofNullable(inputCsv), Optional.ofNullable(batchSize), Optional.ofNullable(threadCount),
+                    help);
         }
 
         private static String requireValue(String currentArg, String[] args, int valueIndex) {
@@ -100,12 +118,30 @@ public final class BatchBlobDeleteApplication {
             return args[valueIndex];
         }
 
+        private static int parsePositiveInt(String rawValue, String description, Integer maxValue) {
+            try {
+                int parsedValue = Integer.parseInt(rawValue);
+                if (parsedValue <= 0) {
+                    throw new IllegalArgumentException(description + " must be greater than zero");
+                }
+                if (maxValue != null && parsedValue > maxValue) {
+                    throw new IllegalArgumentException(
+                            description + " must not exceed " + maxValue + ", but was " + parsedValue);
+                }
+                return parsedValue;
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Invalid value for " + description + ": '" + rawValue + "'", ex);
+            }
+        }
+
         static void printUsage() {
             String usage = "Usage: java -jar batch-blob-delete.jar [options]\n" +
                     "Options:\n" +
                     "  -c, --config <path>       Path to configuration file (default: config/application.properties)\n" +
                     "  -f, --input-file <path>   Override input CSV file path\n" +
                     "  -d, --input-data <csv>    Provide inline CSV data (mutually exclusive with --input-file)\n" +
+                    "  -b, --batch-size <size>   Override batch size (max 256)\n" +
+                    "  -t, --threads <count>     Override thread pool size\n" +
                     "  -h, --help                Show this help message";
             System.out.println(usage);
         }

--- a/src/main/java/com/example/batchdelete/config/AppConfig.java
+++ b/src/main/java/com/example/batchdelete/config/AppConfig.java
@@ -83,11 +83,11 @@ public final class AppConfig {
     }
 
     public static AppConfig load(Path path) throws IOException {
-        return load(path, null, null);
+        return load(path, null, null, null, null);
     }
 
-    public static AppConfig load(Path path, String overrideInputFilePath, String overrideInputCsvContent)
-            throws IOException {
+    public static AppConfig load(Path path, String overrideInputFilePath, String overrideInputCsvContent,
+            Integer overrideBatchSize, Integer overrideThreadPoolSize) throws IOException {
         Properties properties = new Properties();
         try (InputStream inputStream = Files.newInputStream(path)) {
             properties.load(inputStream);
@@ -106,8 +106,9 @@ public final class AppConfig {
         }
 
         String storageEndpoint = requireProperty(properties, "storageEndpoint");
-        int batchSize = parseIntProperty(properties, "batchSize", 255);
-        int threadPoolSize = parseIntProperty(properties, "threadPoolSize", Runtime.getRuntime().availableProcessors());
+        int batchSize = overrideBatchSize != null ? overrideBatchSize : parseIntProperty(properties, "batchSize", 255);
+        int threadPoolSize = overrideThreadPoolSize != null ? overrideThreadPoolSize
+                : parseIntProperty(properties, "threadPoolSize", Runtime.getRuntime().availableProcessors());
         String csvSeparator = properties.getProperty("csvSeparator", DEFAULT_SEPARATOR);
         boolean csvHasHeader = parseBooleanProperty(properties, "csvHasHeader", true);
         boolean snapshotEnabled = parseBooleanProperty(properties, "snapshotEnable", false);

--- a/src/main/java/com/example/batchdelete/service/BlobBatchDeletionTask.java
+++ b/src/main/java/com/example/batchdelete/service/BlobBatchDeletionTask.java
@@ -80,6 +80,12 @@ public class BlobBatchDeletionTask implements Callable<BatchDeletionResult> {
                     failureCount += submittedRequests.size();
                     LOGGER.error("Unexpected error when submitting blob batch. Lines: {}",
                             formatLineContexts(submittedRequests), ex);
+                    for (BlobDeleteRequest failedRequest : submittedRequests) {
+                        LOGGER.error(
+                                "Failed to delete blob {} from container {} (line {}) due to batch submission error. Line context: {}",
+                                failedRequest.getBlobName(), failedRequest.getContainerName(),
+                                failedRequest.getLineNumber(), formatLineContext(failedRequest));
+                    }
                     return new BatchDeletionResult(successCount, failureCount);
                 }
 
@@ -120,6 +126,13 @@ public class BlobBatchDeletionTask implements Callable<BatchDeletionResult> {
             failureCount += submittedRequests.isEmpty() ? requests.size() : submittedRequests.size();
             LOGGER.error("Unexpected error when deleting blob batch. Lines: {}",
                     formatLineContexts(submittedRequests.isEmpty() ? requests : submittedRequests), ex);
+            List<BlobDeleteRequest> failedRequests = submittedRequests.isEmpty() ? requests : submittedRequests;
+            for (BlobDeleteRequest failedRequest : failedRequests) {
+                LOGGER.error(
+                        "Failed to delete blob {} from container {} (line {}) due to unexpected batch error. Line context: {}",
+                        failedRequest.getBlobName(), failedRequest.getContainerName(), failedRequest.getLineNumber(),
+                        formatLineContext(failedRequest));
+            }
         }
 
         return new BatchDeletionResult(successCount, failureCount);


### PR DESCRIPTION
## Summary
- add CLI options to override batch size and thread pool size from the command line
- propagate the overrides into the application configuration while respecting the maximum batch size
- return aggregated batch deletion results so the CLI exits with a non-zero status on failures
- emit per-blob error messages when batch submission fails to clarify which items were not deleted

## Testing
- `mvn -q -DskipTests compile` *(fails: missing com.azure.storage.blob.models.BlobSnapshotInfo dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de46606c00832089d9863f01600974