### PR TITLE
Support deleting blobs across multiple storage accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project provides a command line utility that deletes blobs from an Azure St
 ## Features
 
 - Reads the CSV input file line by line to build deletion requests.
+- Supports deleting blobs across multiple Azure Storage accounts in a single run.
 - Configurable batch size, CSV separator and thread pool size.
 - Uses Azure `DefaultAzureCredential` so it can run inside environments with managed identity (e.g. AKS pods).
 - Logs every successful and failed deletion using Log4j 2.
@@ -32,9 +33,6 @@ Runtime configuration is provided through a properties file. An example file is 
 # Path to the input CSV file containing container and blob names to delete.
 inputFilePath=./data/input.csv
 
-# Azure Blob Storage service endpoint, e.g. https://<account-name>.blob.core.windows.net
-storageEndpoint=https://your-storage-account.blob.core.windows.net
-
 # Maximum number of blobs per batch (Azure limit is 256; default is 255)
 batchSize=255
 
@@ -48,14 +46,18 @@ csvSeparator=,
 csvHasHeader=true
 ```
 
+The storage account for each deletion request is provided in the CSV payload, so no endpoint configuration is required in the
+properties file.
+
 At runtime the application looks for `config/application.properties` by default. You can pass a different configuration file path as the first command line argument.
 
 ## CSV Format
 
-The CSV file must contain at least two columns per line:
+The CSV file must contain at least three columns per line:
 
-1. Container name.
-2. Blob name (relative path inside the container).
+1. Storage account name (e.g. `mystorageaccount`) or full blob service endpoint (e.g. `https://mystorageaccount.blob.core.windows.net`).
+2. Container name.
+3. Blob name (relative path inside the container).
 
 Additional columns are ignored. If the file includes a header row, make sure `csvHasHeader` is set to `true` (default).
 
@@ -65,10 +67,10 @@ Alternatively, you can embed the CSV payload directly in the configuration by se
 Example:
 
 ```
-container,blob
-invoices,2024/04/01/invoice-001.pdf
-invoices,2024/04/01/invoice-002.pdf
-archive,backup/file.zip
+storageAccount,container,blob
+mystorageaccount,invoices,2024/04/01/invoice-001.pdf
+mystorageaccount,invoices,2024/04/01/invoice-002.pdf
+archivestorage,archive,backup/file.zip
 ```
 
 ## Building

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,12 +1,9 @@
-# Path to the input CSV file containing container and blob names to delete.
+# Path to the input CSV file containing storage account, container and blob names to delete.
 # Alternatively, comment this out and set inputCsvContent with the CSV payload.
 inputFilePath=./data/input.csv
 
 # Example inline CSV configuration (uncomment to use instead of inputFilePath)
-# inputCsvContent="container,blob\narchive,backup/file.zip"
-
-# Azure Blob Storage service endpoint, e.g. https://<account-name>.blob.core.windows.net
-storageEndpoint=https://your-storage-account.blob.core.windows.net
+# inputCsvContent="storageAccount,container,blob\nmystorageaccount,archive,backup/file.zip"
 
 # Maximum number of blobs per batch (Azure limit is 256; default is 255)
 batchSize=255

--- a/src/main/java/com/example/batchdelete/config/AppConfig.java
+++ b/src/main/java/com/example/batchdelete/config/AppConfig.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -18,14 +17,13 @@ public final class AppConfig {
 
     private final String inputFilePath;
     private final String inputCsvContent;
-    private final String storageEndpoint;
     private final int batchSize;
     private final int threadPoolSize;
     private final String csvSeparator;
     private final boolean csvHasHeader;
     private final boolean snapshotEnabled;
 
-    private AppConfig(String inputFilePath, String inputCsvContent, String storageEndpoint, int batchSize,
+    private AppConfig(String inputFilePath, String inputCsvContent, int batchSize,
             int threadPoolSize, String csvSeparator, boolean csvHasHeader, boolean snapshotEnabled) {
         if (batchSize <= 0 || batchSize > MAX_BATCH_SIZE) {
             throw new IllegalArgumentException(
@@ -42,7 +40,6 @@ public final class AppConfig {
         }
         this.inputFilePath = inputFilePath == null || inputFilePath.isBlank() ? null : inputFilePath;
         this.inputCsvContent = inputCsvContent == null || inputCsvContent.isBlank() ? null : inputCsvContent;
-        this.storageEndpoint = Objects.requireNonNull(storageEndpoint, "storageEndpoint");
         this.batchSize = batchSize;
         this.threadPoolSize = threadPoolSize;
         this.csvSeparator = csvSeparator == null || csvSeparator.isEmpty() ? DEFAULT_SEPARATOR : csvSeparator;
@@ -56,10 +53,6 @@ public final class AppConfig {
 
     public Optional<String> getInputCsvContent() {
         return Optional.ofNullable(inputCsvContent);
-    }
-
-    public String getStorageEndpoint() {
-        return storageEndpoint;
     }
 
     public int getBatchSize() {
@@ -105,7 +98,6 @@ public final class AppConfig {
                     "Either inputFilePath or inputCsvContent must be provided (config or CLI override).");
         }
 
-        String storageEndpoint = requireProperty(properties, "storageEndpoint");
         int batchSize = overrideBatchSize != null ? overrideBatchSize : parseIntProperty(properties, "batchSize", 255);
         int threadPoolSize = overrideThreadPoolSize != null ? overrideThreadPoolSize
                 : parseIntProperty(properties, "threadPoolSize", Runtime.getRuntime().availableProcessors());
@@ -113,16 +105,8 @@ public final class AppConfig {
         boolean csvHasHeader = parseBooleanProperty(properties, "csvHasHeader", true);
         boolean snapshotEnabled = parseBooleanProperty(properties, "snapshotEnable", false);
 
-        return new AppConfig(inputFilePath, inputCsvContent, storageEndpoint, batchSize, threadPoolSize, csvSeparator,
+        return new AppConfig(inputFilePath, inputCsvContent, batchSize, threadPoolSize, csvSeparator,
                 csvHasHeader, snapshotEnabled);
-    }
-
-    private static String requireProperty(Properties properties, String propertyName) {
-        String value = properties.getProperty(propertyName);
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("Missing required property '" + propertyName + "'.");
-        }
-        return value;
     }
 
     private static int parseIntProperty(Properties properties, String propertyName, int defaultValue) {

--- a/src/main/java/com/example/batchdelete/io/CsvBlobDeleteRequestReader.java
+++ b/src/main/java/com/example/batchdelete/io/CsvBlobDeleteRequestReader.java
@@ -132,21 +132,22 @@ public class CsvBlobDeleteRequestReader {
         }
 
         String[] tokens = splitPattern.split(trimmed, -1);
-        if (tokens.length < 2) {
-            LOGGER.error("Invalid CSV line {} in {}: expected at least 2 tokens but found {}. Line content: {}",
+        if (tokens.length < 3) {
+            LOGGER.error("Invalid CSV line {} in {}: expected at least 3 tokens but found {}. Line content: {}",
                     lineNumber, sourceDescription, tokens.length, line);
             return null;
         }
 
-        String containerName = stripQuotes(tokens[0]);
-        String blobName = stripQuotes(tokens[1]);
-        if (containerName.isEmpty() || blobName.isEmpty()) {
-            LOGGER.error("Invalid CSV line {} in {}: container or blob name missing. Line content: {}",
+        String storageAccountName = stripQuotes(tokens[0]);
+        String containerName = stripQuotes(tokens[1]);
+        String blobName = stripQuotes(tokens[2]);
+        if (storageAccountName.isEmpty() || containerName.isEmpty() || blobName.isEmpty()) {
+            LOGGER.error("Invalid CSV line {} in {}: storage account, container or blob name missing. Line content: {}",
                     lineNumber, sourceDescription, line);
             return null;
         }
 
-        return new BlobDeleteRequest(containerName, blobName, lineNumber, line);
+        return new BlobDeleteRequest(storageAccountName, containerName, blobName, lineNumber, line);
     }
 
     private static ReaderFactory createFileReaderFactory(Path csvPath) {

--- a/src/main/java/com/example/batchdelete/model/BlobDeleteRequest.java
+++ b/src/main/java/com/example/batchdelete/model/BlobDeleteRequest.java
@@ -7,16 +7,23 @@ import java.util.Objects;
  */
 public final class BlobDeleteRequest {
 
+    private final String storageAccountName;
     private final String containerName;
     private final String blobName;
     private final long lineNumber;
     private final String rawLine;
 
-    public BlobDeleteRequest(String containerName, String blobName, long lineNumber, String rawLine) {
+    public BlobDeleteRequest(String storageAccountName, String containerName, String blobName, long lineNumber,
+            String rawLine) {
+        this.storageAccountName = Objects.requireNonNull(storageAccountName, "storageAccountName");
         this.containerName = Objects.requireNonNull(containerName, "containerName");
         this.blobName = Objects.requireNonNull(blobName, "blobName");
         this.lineNumber = lineNumber;
         this.rawLine = rawLine;
+    }
+
+    public String getStorageAccountName() {
+        return storageAccountName;
     }
 
     public String getContainerName() {
@@ -38,7 +45,8 @@ public final class BlobDeleteRequest {
     @Override
     public String toString() {
         return "BlobDeleteRequest{" +
-                "containerName='" + containerName + '\'' +
+                "storageAccountName='" + storageAccountName + '\'' +
+                ", containerName='" + containerName + '\'' +
                 ", blobName='" + blobName + '\'' +
                 ", lineNumber=" + lineNumber +
                 '}';


### PR DESCRIPTION
## Summary
- parse the CSV input with storage account values and store them on each delete request
- process blob deletions per storage account with dedicated batch clients and derived endpoints
- refresh the documentation and sample configuration to describe the new CSV format and removal of the storage endpoint setting

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68df7a51bb9083209f4ce04c076cf631