### PR TITLE
Add rolling file logging and expose per-blob outcomes

### DIFF
--- a/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
+++ b/src/main/java/com/example/batchdelete/BatchBlobDeleteApplication.java
@@ -44,6 +44,8 @@ public final class BatchBlobDeleteApplication {
 
             BlobBatchDeletionService service = new BlobBatchDeletionService(config);
             BatchDeletionResult result = service.execute();
+            result.failureMessages().forEach(System.out::println);
+            result.successMessages().forEach(System.out::println);
             if (result.failureCount() > 0) {
                 LOGGER.error("Batch completed with {} failures", result.failureCount());
                 System.exit(1);

--- a/src/main/java/com/example/batchdelete/service/BatchDeletionResult.java
+++ b/src/main/java/com/example/batchdelete/service/BatchDeletionResult.java
@@ -1,12 +1,34 @@
 package com.example.batchdelete.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Result for a single batch deletion execution.
  */
-public record BatchDeletionResult(int successCount, int failureCount) {
+
+public record BatchDeletionResult(int successCount, int failureCount, List<String> successMessages,
+        List<String> failureMessages) {
+
+    public BatchDeletionResult {
+        successMessages = List.copyOf(successMessages);
+        failureMessages = List.copyOf(failureMessages);
+    }
+
+    public BatchDeletionResult(int successCount, int failureCount) {
+        this(successCount, failureCount, List.of(), List.of());
+    }
 
     public BatchDeletionResult add(BatchDeletionResult other) {
+        List<String> combinedSuccessMessages = new ArrayList<>(this.successMessages);
+        combinedSuccessMessages.addAll(other.successMessages);
+
+        List<String> combinedFailureMessages = new ArrayList<>(this.failureMessages);
+        combinedFailureMessages.addAll(other.failureMessages);
+
         return new BatchDeletionResult(this.successCount + other.successCount,
-                this.failureCount + other.failureCount);
+                this.failureCount + other.failureCount,
+                combinedSuccessMessages,
+                combinedFailureMessages);
     }
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
+        <RollingFile name="FileLogger" fileName="batchDeletion.log"
+                     filePattern="batchDeletion-%d{yyyy-MM-dd}.log">
             <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n"/>
-        </Console>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+            </Policies>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="info">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="FileLogger"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Summary
- configure Log4j2 to write application logs to a daily rolling `batchDeletion.log`
- collect success and failure messages for each blob, including the storage account name
- print the per-blob outcomes so CLI callers can capture deletion results

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68df9a91d5808320ab99ce90717559b0