### PR TITLE
Add CLI option to override snapshotEnabled flag

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -18,4 +18,4 @@ csvSeparator=,
 csvHasHeader=true
 
 # Controls whether a blob snapshot is created prior to deletion to enable soft-delete recovery
-snapshotEnable=true
+snapshotEnabled=true


### PR DESCRIPTION
## Summary
- add CLI argument to override the snapshotEnabled configuration flag
- pass the optional CLI override into AppConfig and support both snapshotEnabled and legacy snapshotEnable keys
- update the default properties file to use the corrected snapshotEnabled name

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dfa2bcbee88320bc5af0ecb1647c8d